### PR TITLE
Optimization: Minify images and CSS for production builds

### DIFF
--- a/web-starter/index.js
+++ b/web-starter/index.js
@@ -45,6 +45,7 @@ module.exports = class ReactGenerator extends generator.Base {
 
     this._copyFile('webpack.config.js');
     this._copyFile('src/index.tsx');
+    this._copyFile('src/ambient.d.ts');
     this._copyFile('src/sass/styles.scss');
     this._copyFile('src/index.html');
 
@@ -85,6 +86,9 @@ module.exports = class ReactGenerator extends generator.Base {
         'clean-webpack-plugin',
         'browser-sync',
         'browser-sync-webpack-plugin',
+        'imagemin-loader',
+        'imagemin-pngquant',
+        'imagemin-svgo',
       ],
       {
         'save-dev': true,

--- a/web-starter/templates/src/ambient.d.ts
+++ b/web-starter/templates/src/ambient.d.ts
@@ -1,0 +1,26 @@
+// Ambient declarations
+// These declarations tell TypeScript that image assets exist and can be imported using "import * as ..." syntax.
+
+declare module '*.svg' {
+  /**
+   * The Webpack-generated path to this SVG file.
+   */
+  const path: string;
+  export = path;
+}
+
+declare module '*.png' {
+  /**
+   * The Webpack-generated path to this PNG file.
+   */
+  const path: string;
+  export = path;
+}
+
+declare module '*.jpg' {
+  /**
+   * The Webpack-generated path to this JPG file.
+   */
+  const path: string;
+  export = path;
+}

--- a/web-starter/templates/webpack.config.js
+++ b/web-starter/templates/webpack.config.js
@@ -118,7 +118,10 @@ module.exports = {
           use: [
             {
               loader: 'css-loader',
-              options: { sourceMap: !isProduction },
+              options: {
+                minimize: isProduction,
+                sourceMap: !isProduction,
+              },
             },
             {
               loader: 'postcss-loader',

--- a/web-starter/templates/webpack.config.js
+++ b/web-starter/templates/webpack.config.js
@@ -12,6 +12,9 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 const targetDir = path.resolve(__dirname, 'public');
 
+// Automatically inline any image less than this size
+const inlineThreshold = 8 * 1024;
+
 // We always use these plugins
 const standardPlugins = [
   new CleanWebpackPlugin([targetDir]),
@@ -74,19 +77,61 @@ module.exports = {
 
   module: {
     rules: [
-      // Static assets
-      // Anything less than 8KB is inlined automatically. Otherwise, webpack outputs
-      // them as separate files.
+      // Static assets:
+      // Assets are automatically inlined if their size is less than the value of the `inlineThreshold' variable.
       {
         test: /\.(?:png|svg|jpg)$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            name: '[name]-[hash].[ext]',
-            limit: 8192,
+        exclude: [
+          // The 'exclude' array here is used to exempt images from minimization.
+          // Be sure to check the configuration block below this! Your Webpack build will fail if you don't pass the exempted images through url-loader.
+          // path.resolve(__dirname, 'src/images/filename.ext'),
+        ],
+        use: [
+          {
+            loader: 'url-loader',
+            options: {
+              name: '[name]-[hash].[ext]',
+              limit: inlineThreshold,
+            },
           },
-        },
+          {
+            loader: 'imagemin-loader',
+            options: {
+              enabled: isProduction,
+              plugins: [
+                {
+                  use: 'imagemin-pngquant',
+                  options: {
+                    quality: '50-60',
+                  },
+                },
+                {
+                  use: 'imagemin-svgo',
+                },
+              ],
+            },
+          },
+        ],
       },
+
+      // Image optimization exceptions:
+      // If any images look terrible after a production build:
+      // 1) Add the FULL path to the 'exclude' array in the configuration above this,
+      // 2) Uncomment the block below, and
+      // 3) Add the path again to the 'include' array
+      // {
+      //   test: /\.(?:png|svg|jpg)$/,
+      //   include: [
+      //     // path.resolve(__dirname, 'src/images/filename.ext'),
+      //   ],
+      //   use: {
+      //     loader: 'url-loader',
+      //     options: {
+      //       name: '[name]-[hash].[ext]',
+      //       limit: inlineThreshold,
+      //     },
+      //   },
+      // },
 
       // Scripts
       {


### PR DESCRIPTION
This PR adds two optimization features, enabled only during production builds:

1. CSS is minified by css-loader (this passes through to cssnano).
2. Image assets are passed through imagemin. In webpack.config.js there is an escape hatch to exclude certain files from this, in case minimization somehow breaks them.