### PR TITLE
Capistrano compatibility: Ensure docroot is set 

### DIFF
--- a/web-starter/index.js
+++ b/web-starter/index.js
@@ -28,6 +28,9 @@ module.exports = class ReactGenerator extends generator.Base {
   configuring() {
     this.options.addToGitignore(this._readFile('_gitignore'));
     this.options.addToGitattributes(this._readFile('_gitattributes'));
+    this.options.addService('web', {
+      doc_root: 'public',
+    });
   }
 
   _copyFileAs(sourceFilename, targetFilename) {


### PR DESCRIPTION
Like other platforms, we have to expose the `'web'` service to web-starter in order for Capistrano to be able to generate its deploy scripts.