### PR TITLE
Updates from real-world usage

### DIFF
--- a/web-starter/index.js
+++ b/web-starter/index.js
@@ -99,12 +99,13 @@ module.exports = class ReactGenerator extends generator.Base {
       }
     );
 
-    // Install TypeScript with an exact version so as to avoid breaking changes (the save-dev option creates a caret range, which isn't what we want)
-    this.npmInstall(['typescript'], { 'save-dev': true, 'save-exact': true });
+    // Install both TypeScript and the helper tslib library with an exact version to avoid breaking changes
+    // (By default, --save-dev uses a caret range, which isn't what we want)
+    this.npmInstall(['typescript', 'tslib'], { 'save-dev': true, 'save-exact': true });
 
+    // TypeScript tooling
     this.npmInstall(
       [
-        // TypeScript tooling
         'awesome-typescript-loader',
         'tslint',
         'tslint-loader',

--- a/web-starter/templates/tsconfig.json
+++ b/web-starter/templates/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
 
     "importHelpers": true,
 

--- a/web-starter/templates/tslint.json
+++ b/web-starter/templates/tslint.json
@@ -116,7 +116,8 @@
       "options": [
         "check-format",
         "allow-pascal-case",
-        "ban-keywords"
+        "ban-keywords",
+        "allow-leading-underscore"
       ]
     },
     "whitespace": {

--- a/web-starter/templates/webpack.config.js
+++ b/web-starter/templates/webpack.config.js
@@ -70,7 +70,12 @@ module.exports = {
   devServer: {
     host: '0.0.0.0',
     port: 8000,
+
+    // Show errors in the browser
     overlay: true,
+
+    // Don't fall back to the filesystem during development
+    contentBase: false,
   },
 
   plugins: standardPlugins.concat(isProduction ? prodPlugins : devPlugins),


### PR DESCRIPTION
This addresses a few issues we've seen using the generator's scaffolded system. The changes here should only merit a patch-level update.

**Changes**:
1. The tslib helpers module needs to be explicitly installed in order for Webpack running on older node versions (i.e., 4 and below) to discover it.
2. webpack-dev-server includes a default [content base](https://webpack.js.org/configuration/dev-server/#devserver-contentbase) that falls back to serving from the filesystem. This PR explicitly disables it in order to prevent a situation where assets show during local development but not when the bundle is deployed.
3. tslint.json accidentally banned leading underscores in variable names, which conflicts with the following idiom when `noUnusedParameters` is in effect:

    ```ts
    // Explicitly declare that `_x' may be unused
    function foo(_x, y) {
      console.log(y);
    }
    ```
4. Per the [TypeScript roadmap](https://github.com/Microsoft/TypeScript/wiki/Roadmap#27-january-2018), CommonJS/AMD interop is being revisited. By enabling `allowSyntheticDefaultImports` now, we will be closer in line when the changes arrive in 2.7 or later versions. (At time of writing, this option results in incorrect CommonJS module output, but since we're using ES modules for Webpack, this won't affect our front-end projects.)